### PR TITLE
clear out listings any time the search page re-mounts, assuming incom…

### DIFF
--- a/client/src/pages/Search.js
+++ b/client/src/pages/Search.js
@@ -12,6 +12,7 @@ const Search = () => {
     searchedCity.charAt(0).toUpperCase() + searchedCity.slice(1).toLowerCase();
 
   useEffect(() => {
+    setListings([]);
     API.getRentals(city).then((results) => {
       console.log(results);
       setListings(results);


### PR DESCRIPTION
Clear out listings context state any time the search page re-mounts, assuming incoming API return when re-navigating to the page. Loading spinner will now render between searches.