### PR TITLE
finish front-end signout fn using authContext

### DIFF
--- a/client/src/components/Logout/Logout.js
+++ b/client/src/components/Logout/Logout.js
@@ -1,25 +1,21 @@
-import {useEffect, useState} from "react"
-import {useHistory } from "react-router-dom"
+import { useEffect, useState, useHistory } from "react"
+import { useHistory } from "react-router-dom"
 import axios from "axios";
+import { useAuth } from "../../utils/authContext";
 
 const Logout = () => {
     const history = useHistory();
     const [error, setError] = useState(null)
 
+    const auth = useAuth();
+
     useEffect(() => {
-      axios.get('/api/logout').then((json) => {
-          console.log("json.data", json.data);
-        
-        // if (json.data.message === 'logged out') 
-        history.push('/signin')
-      }).catch(e => {
-        setError(e)
-        console.log("🚀 ~ file: Logout.js ~ line 17 ~ axios.get ~ e", e)
-      })
+        auth.signout(() => history.replace("/signin"));
+
     }, [])
     if (error) return <div>Unable to logout</div>
 
     return <></>
-  }
+}
 
-  export default Logout;
+export default Logout;


### PR DESCRIPTION
This file should have been committed with previous logout functionality pull request #26 

The axios.get('/api/logout') call was moved to the front-end API and called through signout function in authContext - this in turn is called by auth.signout in the Logout component, which passes back `history.replace("/signin")` as the callback to be executed upon user state set to null. 